### PR TITLE
Make npm related shields in README redirect to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vuiet ![](https://img.shields.io/npm/v/vuiet?color=blue) ![](https://img.shields.io/npm/dm/vuiet?color=blue)
+# Vuiet <a href="https://www.npmjs.com/package/vuiet" target="_blank">![](https://img.shields.io/npm/v/vuiet?color=blue)</a> <a href="https://www.npmjs.com/package/vuiet" target="_blank">![](https://img.shields.io/npm/dm/vuiet?color=blue)</a>
 
 Vuiet is a minimal wallet manager built on the Sui blockchain for Vue 3.
 


### PR DESCRIPTION
Before shields would've only redirected to their source. This would make it so they redirect to the npm package which is way more useful.